### PR TITLE
fix(MathJax): enable auto horizontal scrolling on LaTeX line overflows

### DIFF
--- a/sass/parts/_latex.scss
+++ b/sass/parts/_latex.scss
@@ -1,0 +1,8 @@
+/* NOTE: MathJax doesn't support line wrapping yet as of v3 and 2025-02-14.
+ This isn't necessarily the best formatting option IMO as it forces the user
+ to scroll to see the full content but it is better than before without
+ horizontal scrolling.
+ */
+mjx-container {
+  overflow-x: auto;
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -5,6 +5,7 @@
 @use "parts/code";
 @use "parts/search";
 @use "parts/toc";
+@use "parts/latex";
 
 :root {
   --note-color: #00c6ff;


### PR DESCRIPTION
Fixes #5. 

Note:
- MathJax doesn't support line wrapping yet as of v3 and 2025-02-14, so this is the best available alternative styling IMO