### PR TITLE
Feature/post revision history

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ site demo [here](https://micahkepe.com/radion/).
   - [Light and Dark Modes](#light-and-dark-modes)
   - [Table of Contents](#table-of-contents)
   - [Comments](#comments)
+  - [Post Revision History](#post-revision-history)
 - [Acknowledgements](#acknowledgements)
 
 ## Installation
@@ -174,7 +175,6 @@ To change the default favicon:
 
 1. Create your own favicon folder with the following site:
    [RealFaviconGenerator](https://realfavicongenerator.net/)
-
    - Set the 'Favicon path' option to `/icons/favicon/`
 
 2. Unzip the created folder
@@ -309,6 +309,31 @@ The `config.toml` value for `comments` takes precedence and priority. For
 example, if you globally disable comments in your `config.toml` by setting
 `comments = false`, then trying to enabling comments through a page's front
 matter will have no effect.
+
+### Post Revision History
+
+To enable revision history links that allow readers to view the commit history
+for individual posts, configure the following in your `config.toml`:
+
+```toml
+[extra]
+# Enable revision history globally
+revision_history = true
+# Your blog's GitHub repository URL
+blog_github_repo_url = "https://github.com/username/repository-name"
+```
+
+Revision history can be enabled or disabled on a per-page basis by adding the
+following to a page's front matter:
+
+```toml
+[extra]
+revision_history = true  # or false to disable for this page
+```
+
+When enabled, a "(revision history)" link will appear in the page footer that
+links directly to the GitHub commit history for that specific content file,
+allowing readers to see how the post has evolved over time.
 
 ---
 

--- a/config.toml
+++ b/config.toml
@@ -63,3 +63,7 @@ comments = true
 giscus_repo = "micahkepe/radion"
 giscus_repo_id = "R_kgDONK7lCQ"
 giscus_data_category_id = "DIC_kwDONK7lCc4CnfXf"
+
+# Post revision history
+revision_history = true
+blog_github_repo_url = "https://github.com/micahkepe/radion"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,3 +1,4 @@
 +++
 paginate_by = 5
+sort_by = "date"
 +++

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -145,7 +145,6 @@ To change the default favicon:
 
 1. Create your own favicon folder with the following site:
    [RealFaviconGenerator](https://realfavicongenerator.net/)
-
    - Set the 'Favicon path' option to `/icons/favicon/`
 
 2. Unzip the created folder
@@ -283,6 +282,31 @@ The `config.toml` value for `comments` takes precedence and priority. For
 example, if you globally disable comments in your `config.toml` by setting
 `comments = false`, then trying to enabling comments through a page's front
 matter will have no effect.
+
+### Post Revision History
+
+To enable revision history links that allow readers to view the commit history
+for individual posts, configure the following in your `config.toml`:
+
+```toml
+[extra]
+# Enable revision history globally
+revision_history = true
+# Your blog's GitHub repository URL
+blog_github_repo_url = "https://github.com/username/repository-name"
+```
+
+Revision history can be enabled or disabled on a per-page basis by adding the
+following to a page's front matter:
+
+```toml
+[extra]
+revision_history = true  # or false to disable for this page
+```
+
+When enabled, a "(revision history)" link will appear in the page footer that
+links directly to the GitHub commit history for that specific content file,
+allowing readers to see how the post has evolved over time.
 
 ---
 

--- a/content/markdown-demo.md
+++ b/content/markdown-demo.md
@@ -99,9 +99,7 @@ Example of 3-level nested ordered lists:
 
 1. a
 2. First sublist:
-
    1. One (with additional sublist)
-
       1. Another
       2. ordered
       3. sublist.
@@ -118,7 +116,6 @@ Example of 3-level nested ordered lists:
 Example of 3-level nested unordered lists:
 
 - a
-
   - b
   - c
 

--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -263,3 +263,17 @@ article [itemprop="summary"] p {
   margin-left: 0.5em;
   font-size: 1.2em;
 }
+
+/* Post history styling */
+.revision-history {
+  text-align: center;
+  font-style: italic;
+
+  a {
+    border-bottom: none;
+  }
+
+  a::after {
+    content: none;
+  }
+}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -32,6 +32,24 @@
                 {% endfor %}
             {% endif %}
         </p>
+
+        <!-- Revision history (optional) -->
+        {% block revision_history %}
+          {% if config.extra.revision_history | default(value="false") %}
+            {% if page.extra.revision_history | default(value="false") %}
+              {% if config.extra.blog_github_repo_url %}
+                {% set base_url = config.extra.blog_github_repo_url | trim_end_matches(pat="/") %}
+                {% set commits_url = base_url ~ "/commits/main/content/" ~ page.relative_path %}
+                <section class="revision-history">
+                  <a href="{{ commits_url }}" target="_blank" rel="noopener noreferrer">
+                    (revision history)
+                  </a>
+                </section>
+              {% endif %}
+            {% endif %}
+          {% endif %}
+        {% endblock revision_history %}
+
         {% block extra_footer %}
         {% endblock extra_footer %}
     </footer>


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This PR adds a revision history feature that allows readers to view the commit history for individual blog posts. The feature adds a "(revision history)" link in the page footer that directs users to the GitHub commits page for that specific content file, providing transparency about how posts have evolved over time.

Configuration:

```toml
# Global configuration in config.toml
[extra]
revision_history = true
blog_github_repo_url = "https://github.com/username/repository-name"

# Per-page configuration in frontmatter
[extra]
revision_history = true  # or false to disable
```


## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Dark mode:

<img width="806" height="162" alt="Screenshot 2025-09-07 at 8 37 52 PM" src="https://github.com/user-attachments/assets/595beb94-01cf-4f9d-a68e-5983f45a006d" />

Light mode:
<img width="806" height="162" alt="Screenshot 2025-09-07 at 8 38 22 PM" src="https://github.com/user-attachments/assets/be6a02d8-baec-466e-80b2-59a67cc9f0a5" />

