### PR TITLE
feat(open-graph): add `cover_image` page option for Open Graph cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ site demo [here](https://micahkepe.com/radion/).
 - [x] Table of Contents option
 - [x] Footnote support
 - [x] Built-in comments option (Giscus)
+- [x] Open Graph cover image selection
 
 ## Contents and Configuration Guide
 
@@ -49,6 +50,7 @@ site demo [here](https://micahkepe.com/radion/).
   - [Table of Contents](#table-of-contents)
   - [Comments](#comments)
   - [Post Revision History](#post-revision-history)
+  - [Set Post Open Graph Image (Cover Image)](#set-post-open-graph-image-cover-image)
 - [Acknowledgements](#acknowledgements)
 
 ## Installation
@@ -334,6 +336,51 @@ revision_history = true  # or false to disable for this page
 When enabled, a "(revision history)" link will appear in the page footer that
 links directly to the GitHub commit history for that specific content file,
 allowing readers to see how the post has evolved over time.
+
+### Set Post Open Graph Image (Cover Image)
+
+[Open Graph](https://ogp.me/) is a standard for embedding rich previews of
+content on the Internet. It is used by social media platforms like Facebook,
+Twitter, and LinkedIn to display a preview of a page when a user shares the
+page on their social media network.
+
+For example, to set the Open Graph image for a post `my-post` to be the page
+asset `cover.png`, add the following to the front matter of the post:
+
+1. Make sure the image is located in the page's content directory (i.e.
+   `content/my-post/`. For example:
+
+   ```
+   content/
+   └── my-post/
+       ├── index.md
+       ├── cover.png        # Your cover image
+       └── assets/
+           └── other-image.jpg
+   ```
+
+   or
+
+   ```
+   content/
+   └── my-post/
+       ├── index.md
+       └── assets/
+           ├── other-image.jpg
+           └── cover.png    # Your cover image
+   ```
+
+2. Add the following to the front matter of the post:
+
+```toml
+[extra]
+cover_image = "cover.png"
+```
+
+> [!NOTE]
+> The image must be located within the page's content directory and
+> `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
+> a path like `"assets/cover.png"`). The first filename match will be used.
 
 ---
 

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -308,6 +308,50 @@ When enabled, a "(revision history)" link will appear in the page footer that
 links directly to the GitHub commit history for that specific content file,
 allowing readers to see how the post has evolved over time.
 
+### Set Post Open Graph Image (Cover Image)
+
+[Open Graph](https://ogp.me/) is a standard for embedding rich previews of
+content on the Internet. It is used by social media platforms like Facebook,
+Twitter, and LinkedIn to display a preview of a page when a user shares the
+page on their social media network.
+
+For example, to set the Open Graph image for a post `my-post` to be the page
+asset `cover.png`, add the following to the front matter of the post:
+
+1. Make sure the image is located in the page's content directory (i.e.
+   `content/my-post/`. For example:
+
+   ```
+   content/
+   └── my-post/
+       ├── index.md
+       ├── cover.png        # Your cover image
+       └── assets/
+           └── other-image.jpg
+   ```
+
+   or
+
+   ```
+   content/
+   └── my-post/
+       ├── index.md
+       └── assets/
+           ├── other-image.jpg
+           └── cover.png    # Your cover image
+   ```
+
+2. Add the following to the front matter of the post:
+
+```toml
+[extra]
+cover_image = "cover.png"
+```
+
+> **NOTE**: The image must be located within the page's content directory and
+> `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
+> a path like `"assets/cover.png"`). The first filename match will be used.
+
 ---
 
 ## Acknowledgements

--- a/content/shortcodes-demo/index.md
+++ b/content/shortcodes-demo/index.md
@@ -5,6 +5,9 @@ date = 2017-09-24
 [taxonomies]
 categories = ["demo"]
 tags = ["gif", "fancy"]
+
+[extra]
+cover_image = "ferris.png"
 +++
 
 **radion** comes with some handy shortcodes to make your life easier and

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -46,10 +46,6 @@
       content="{% if page %}article{% else %}website{% endif %}"
     />
     <meta property="og:title" content="{{ title }}" />
-    <meta
-      property="og:image"
-      content="{{ config.base_url }}/icons/favicon/web-app-manifest-512x512.png"
-    />
 
     <!-- Additional Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -58,10 +54,29 @@
       content="{% if page %}{{ page.permalink }}{% else %}{{ config.base_url }}{% endif %}"
     />
     <meta name="twitter:title" content="{{ title }}" />
+
+    <!-- Cover images -->
+    {% set cover_image = config.base_url ~ "/icons/favicon/web-app-manifest-512x512.png" %}
+    {% if page and page.extra.cover_image and page.assets %}
+      {% for asset in page.assets %}
+        {% if asset is ending_with(page.extra.cover_image) %}
+          {% set_global cover_image = config.base_url ~ asset %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    <meta
+      property="og:image"
+      content="{{ cover_image }}"
+    />
+
     <meta
       name="twitter:image"
-      content="{{ config.base_url }}/icons/favicon/web-app-manifest-512x512.png"
+      content="{{ cover_image }}"
     />
+
+
 
     <!-- Favicons -->
     {% if config.extra.favicon | default (value="true") %}


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
[Open Graph](https://ogp.me/) is a standard for embedding rich previews of
content on the Internet. It is used by social media platforms like Facebook,
Twitter, and LinkedIn to display a preview of a page when a user shares the
page on their social media network.

For example, to set the Open Graph image for a post `my-post` to be the page
asset `cover.png`, add the following to the front matter of the post:

1. Make sure the image is located in the page's content directory (i.e.
   `content/my-post/`. For example:

   ```
   content/
   └── my-post/
       ├── index.md
       ├── cover.png        # Your cover image
       └── assets/
           └── other-image.jpg
   ```

   or

   ```
   content/
   └── my-post/
       ├── index.md
       └── assets/
           ├── other-image.jpg
           └── cover.png    # Your cover image
   ```

2. Add the following to the front matter of the post:

```toml
[extra]
cover_image = "cover.png"
```

> [!NOTE]
> The image must be located within the page's content directory and
> `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
> a path like `"assets/cover.png"`). The first filename match will be used.

## Approach

- Search page assets (through `page.assets`) for first match of cover image filename and set OG meta tags
- Default to web-app-manifest-512x512 file if cover image doesn't exist or is invalid

