### PR TITLE
New feature: Custom font and auto sync giscus theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ site demo [here](https://micahkepe.com/radion/).
     - [Comments](#comments)
     - [Post Revision History](#post-revision-history)
     - [Set Post Open Graph Image (Cover Image)](#set-post-open-graph-image-cover-image)
-    - [Custom Font](#custom-font)
+    - [Custom Fonts](#custom-fonts)
   - [Acknowledgements](#acknowledgements)
 
 ## Installation
@@ -295,7 +295,7 @@ toc = true
 
 First, follow the instructions at [giscus.app](https://giscus.app/).
 This includes installing the Giscus app and enabling discussions on the
-GitHup repository that you host the website code. Additionally, fill in the
+GitHub repository that you host the website code. Additionally, fill in the
 repository path in the prompt. Then, from the generated script, fill in the
 corresponding values in the `config.toml`:
 
@@ -304,8 +304,8 @@ corresponding values in the `config.toml`:
 comments = true  # {true, false}; sets global enabling of comments by default
 giscus_repo = "FILL ME IN"
 giscus_repo_id = "FILL ME IN"
-giscus_data_category = "FILL ME IN" # Default to "General"
 giscus_data_category_id = "FILL ME IN"
+# giscus_data_category = "General" # Default to "General"
 ```
 
 Comments can be enabled or disabled on a per page basis by editing the page's
@@ -391,25 +391,66 @@ cover_image = "cover.png"
 > `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
 > a path like `"assets/cover.png"`). The first filename match will be used.
 
-### Custom Font
+### Custom Fonts
 
-Currently three font cdn sites are supported:
+Currently three font CDN sites are supported:
 
-- [Google Font (`"googlefont"`)](https://fonts.google.com/)
-- [Fontsource (`"fontsource"`)](https://fontsource.org/)
-- [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
+1. [Google Font (`"googlefont"`)](https://fonts.google.com/): Fonts from `fonts.google.com`
+2. [Fontsource (`"fontsource"`)](https://fontsource.org/): Self-hosted fonts from `fontsource.org`. Uses WOFF2 files.
+3. [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/): Fonts from
+   `fonts.zeoseven.com`. Requires a `font_id` for URL construction.
 
-`font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
+To configure, add entries under `[extra]` in your `config.toml`:
 
-| Config                      | Default Value                                                |
-| --------------------------- | ------------------------------------------------------------ |
-| `config.extra.font_cdn`     | `"googlefont"`                                               |
-| `config.extra.font_weights` | `[400, 700]` if not using `"zeoseven"`, otherwise `["main"]` |
-| `config.extra.font_name`    | `"JetBrains Mono"`                                           |
-| `config.extra.font_display` | `"swap"`                                                     |
-| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn`               |
+| Option          | Type   | Default            | Description                                                                |
+| --------------- | ------ | ------------------ | -------------------------------------------------------------------------- |
+| `font_cdn`      | String | `"googlefont"`     | Font provider: `"googlefont"`, `"fontsource"`, `"zeoseven"`, or `"custom"` |
+| `font_name`     | String | `"JetBrains Mono"` | Font family name (e.g., `"Inter"`, `"Roboto"`)                             |
+| `font_weights`  | Array  | (_See below_)      | Weights to load (provider-specific format)                                 |
+| `font_display`  | String | `"swap"`           | CSS `font-display` value: `"swap"`, `"block"`, `"auto"`, etc.              |
+| `font_id`       | Number | _None_             | **ZeoSeven only**: Numeric ID from font URL                                |
+| `font_css_urls` | Array  | _None_             | **Custom only**: Array of CSS URLs for font definitions                    |
 
-You can also use other font cdn by changing `config.extra.font_cdn` to `"custom"` and provide `font_name` and a `font_css_urls` array. It also enables you to use local fonts.
+#### Font Weights by Provider
+
+| Provider     | Format           | Example      |
+| ------------ | ---------------- | ------------ |
+| Google Fonts | Array of numbers | `[400, 700]` |
+| Fontsource   | Array of strings | `["main"]`   |
+| ZeoSeven     | Array of numbers | `[400, 700]` |
+
+#### Examples
+
+```toml
+# Google Fonts
+[extra]
+font_cdn = "googlefont"
+font_name = "Inter"
+font_weights = [300, 400, 500, 700]
+font_display = "swap"
+
+# Fontsource
+[extra]
+font_cdn = "fontsource"
+font_name = "JetBrains Mono"
+font_weights = ["main"]
+
+# ZeoSeven
+[extra]
+font_cdn = "zeoseven"
+font_name = "Custom Font"
+font_id = 443
+font_weights = [400, 700]
+
+# Custom CSS
+[extra]
+font_cdn = "custom"
+font_name = "My Custom Font"
+font_css_urls = [
+    "https://example.com/fonts/custom-font.css",
+    "https://cdn.example.com/typography.css"
+]
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,22 +36,30 @@ site demo [here](https://micahkepe.com/radion/).
 
 ## Contents and Configuration Guide
 
-- [Installation](#installation)
-- [Options](#options)
-  - [Top menu](#top-menu)
-  - [Title](#title)
-  - [Author Attribution](#author-attribution)
-  - [Favicon](#favicon)
-  - [GitHub](#github)
-  - [Code Snippets](#code-snippets)
-  - [LaTex Support](#latex-support)
-  - [Searchbar](#searchbar)
-  - [Light and Dark Modes](#light-and-dark-modes)
-  - [Table of Contents](#table-of-contents)
-  - [Comments](#comments)
-  - [Post Revision History](#post-revision-history)
-  - [Set Post Open Graph Image (Cover Image)](#set-post-open-graph-image-cover-image)
-- [Acknowledgements](#acknowledgements)
+- [radion](#radion)
+  - [Features](#features)
+  - [Contents and Configuration Guide](#contents-and-configuration-guide)
+  - [Installation](#installation)
+  - [Options](#options)
+    - [Top-menu](#top-menu)
+    - [Title](#title)
+    - [Author Attribution](#author-attribution)
+      - [Defining a Global Default Author in `config.toml`](#defining-a-global-default-author-in-configtoml)
+      - [Defining Author(s) Per-Page](#defining-authors-per-page)
+    - [Favicon](#favicon)
+    - [GitHub](#github)
+    - [Code Snippets](#code-snippets)
+      - [Syntax Highlighting:](#syntax-highlighting)
+      - [Enhanced Codeblocks (Clipboard Support and Language Tags)](#enhanced-codeblocks-clipboard-support-and-language-tags)
+    - [LaTex Support](#latex-support)
+    - [Searchbar](#searchbar)
+    - [Light and Dark Modes](#light-and-dark-modes)
+    - [Table of Contents](#table-of-contents)
+    - [Comments](#comments)
+    - [Post Revision History](#post-revision-history)
+    - [Set Post Open Graph Image (Cover Image)](#set-post-open-graph-image-cover-image)
+    - [Custom Font](#custom-font)
+  - [Acknowledgements](#acknowledgements)
 
 ## Installation
 
@@ -296,6 +304,7 @@ corresponding values in the `config.toml`:
 comments = true  # {true, false}; sets global enabling of comments by default
 giscus_repo = "FILL ME IN"
 giscus_repo_id = "FILL ME IN"
+giscus_data_category = "FILL ME IN" # Default to "General"
 giscus_data_category_id = "FILL ME IN"
 ```
 
@@ -381,6 +390,23 @@ cover_image = "cover.png"
 > The image must be located within the page's content directory and
 > `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
 > a path like `"assets/cover.png"`). The first filename match will be used.
+
+### Custom Font
+
+Currently three font cdn sites are supported:
+- [Google Font (`"googlefont"`)](https://fonts.google.com/)
+- [Fontsource (`"fontsource"`)](https://fontsource.org/)
+- [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
+
+`font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
+
+| Config                      | Default Value                                  |
+|-----------------------------|------------------------------------------------|
+| `config.extra.font_cdn`     | `"googlefont"`                                 |
+| `config.extra.font_weights` | `[400, 700]`                                   |
+| `config.extra.font_name`    | `"JetBrains Mono"`                             |
+| `config.extra.font_display` | `"swap"`                                       |
+| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -394,19 +394,22 @@ cover_image = "cover.png"
 ### Custom Font
 
 Currently three font cdn sites are supported:
+
 - [Google Font (`"googlefont"`)](https://fonts.google.com/)
 - [Fontsource (`"fontsource"`)](https://fontsource.org/)
 - [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
 
 `font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
 
-| Config                      | Default Value                                  |
-|-----------------------------|------------------------------------------------|
-| `config.extra.font_cdn`     | `"googlefont"`                                 |
-| `config.extra.font_weights` | `[400, 700]`                                   |
-| `config.extra.font_name`    | `"JetBrains Mono"`                             |
-| `config.extra.font_display` | `"swap"`                                       |
-| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn` |
+| Config                      | Default Value                                                |
+| --------------------------- | ------------------------------------------------------------ |
+| `config.extra.font_cdn`     | `"googlefont"`                                               |
+| `config.extra.font_weights` | `[400, 700]` if not using `"zeoseven"`, otherwise `["main"]` |
+| `config.extra.font_name`    | `"JetBrains Mono"`                                           |
+| `config.extra.font_display` | `"swap"`                                                     |
+| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn`               |
+
+You can also use other font cdn by changing `config.extra.font_cdn` to `"custom"` and provide `font_name` and a `font_css_urls` array. It also enables you to use local fonts.
 
 ---
 

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -352,6 +352,23 @@ cover_image = "cover.png"
 > `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
 > a path like `"assets/cover.png"`). The first filename match will be used.
 
+### Custom Font
+
+Currently three font cdn sites are supported:
+- [Google Font (`"googlefont"`)](https://fonts.google.com/)
+- [Fontsource (`"fontsource"`)](https://fontsource.org/)
+- [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
+
+`font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
+
+| Config                      | Default Value                                  |
+|-----------------------------|------------------------------------------------|
+| `config.extra.font_cdn`     | `"googlefont"`                                 |
+| `config.extra.font_weights` | `[400, 700]`                                   |
+| `config.extra.font_name`    | `"JetBrains Mono"`                             |
+| `config.extra.font_display` | `"swap"`                                       |
+| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn` |
+
 ---
 
 ## Acknowledgements

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -355,19 +355,22 @@ cover_image = "cover.png"
 ### Custom Font
 
 Currently three font cdn sites are supported:
+
 - [Google Font (`"googlefont"`)](https://fonts.google.com/)
 - [Fontsource (`"fontsource"`)](https://fontsource.org/)
 - [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
 
 `font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
 
-| Config                      | Default Value                                  |
-|-----------------------------|------------------------------------------------|
-| `config.extra.font_cdn`     | `"googlefont"`                                 |
-| `config.extra.font_weights` | `[400, 700]`                                   |
-| `config.extra.font_name`    | `"JetBrains Mono"`                             |
-| `config.extra.font_display` | `"swap"`                                       |
-| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn` |
+| Config                      | Default Value                                                |
+| --------------------------- | ------------------------------------------------------------ |
+| `config.extra.font_cdn`     | `"googlefont"`                                               |
+| `config.extra.font_weights` | `[400, 700]` if not using `"zeoseven"`, otherwise `["main"]` |
+| `config.extra.font_name`    | `"JetBrains Mono"`                                           |
+| `config.extra.font_display` | `"swap"`                                                     |
+| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn`               |
+
+You can also use other font cdn by changing `config.extra.font_cdn` to `"custom"` and provide `font_name` and a `font_css_urls` array. It also enables you to use local fonts.
 
 ---
 

--- a/content/configuration/index.md
+++ b/content/configuration/index.md
@@ -352,25 +352,66 @@ cover_image = "cover.png"
 > `cover_image` expects just the filename of the image (e.g., `"cover.png"`, not
 > a path like `"assets/cover.png"`). The first filename match will be used.
 
-### Custom Font
+### Custom Fonts
 
-Currently three font cdn sites are supported:
+Currently three font CDN sites are supported:
 
-- [Google Font (`"googlefont"`)](https://fonts.google.com/)
-- [Fontsource (`"fontsource"`)](https://fontsource.org/)
-- [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/)
+1. [Google Font (`"googlefont"`)](https://fonts.google.com/): Fonts from `fonts.google.com`
+2. [Fontsource (`"fontsource"`)](https://fontsource.org/): Self-hosted fonts from `fontsource.org`. Uses WOFF2 files.
+3. [ZeoSeven Font (`"zeoseven"`)](https://fonts.zeoseven.com/): Fonts from
+   `fonts.zeoseven.com`. Requires a `font_id` for URL construction.
 
-`font_id` is required when using ZeoSeven. For example, the [Maple Mono](https://fonts.zeoseven.com/items/443/) has its url of `https://fonts.zeoseven.com/items/443/`, so its `font_id` is `443`.
+To configure, add entries under `[extra]` in your `config.toml`:
 
-| Config                      | Default Value                                                |
-| --------------------------- | ------------------------------------------------------------ |
-| `config.extra.font_cdn`     | `"googlefont"`                                               |
-| `config.extra.font_weights` | `[400, 700]` if not using `"zeoseven"`, otherwise `["main"]` |
-| `config.extra.font_name`    | `"JetBrains Mono"`                                           |
-| `config.extra.font_display` | `"swap"`                                                     |
-| `config.extra.font_id`      | Required when using `"zeoseven"` as `font_cdn`               |
+| Option          | Type   | Default            | Description                                                                |
+| --------------- | ------ | ------------------ | -------------------------------------------------------------------------- |
+| `font_cdn`      | String | `"googlefont"`     | Font provider: `"googlefont"`, `"fontsource"`, `"zeoseven"`, or `"custom"` |
+| `font_name`     | String | `"JetBrains Mono"` | Font family name (e.g., `"Inter"`, `"Roboto"`)                             |
+| `font_weights`  | Array  | (_See below_)      | Weights to load (provider-specific format)                                 |
+| `font_display`  | String | `"swap"`           | CSS `font-display` value: `"swap"`, `"block"`, `"auto"`, etc.              |
+| `font_id`       | Number | _None_             | **ZeoSeven only**: Numeric ID from font URL                                |
+| `font_css_urls` | Array  | _None_             | **Custom only**: Array of CSS URLs for font definitions                    |
 
-You can also use other font cdn by changing `config.extra.font_cdn` to `"custom"` and provide `font_name` and a `font_css_urls` array. It also enables you to use local fonts.
+#### Font Weights by Provider
+
+| Provider     | Format           | Example      |
+| ------------ | ---------------- | ------------ |
+| Google Fonts | Array of numbers | `[400, 700]` |
+| Fontsource   | Array of strings | `["main"]`   |
+| ZeoSeven     | Array of numbers | `[400, 700]` |
+
+#### Examples
+
+```toml
+# Google Fonts
+[extra]
+font_cdn = "googlefont"
+font_name = "Inter"
+font_weights = [300, 400, 500, 700]
+font_display = "swap"
+
+# Fontsource
+[extra]
+font_cdn = "fontsource"
+font_name = "JetBrains Mono"
+font_weights = ["main"]
+
+# ZeoSeven
+[extra]
+font_cdn = "zeoseven"
+font_name = "Custom Font"
+font_id = 443
+font_weights = [400, 700]
+
+# Custom CSS
+[extra]
+font_cdn = "custom"
+font_name = "My Custom Font"
+font_css_urls = [
+    "https://example.com/fonts/custom-font.css",
+    "https://cdn.example.com/typography.css"
+]
+```
 
 ---
 

--- a/static/js/toggle-theme.js
+++ b/static/js/toggle-theme.js
@@ -55,11 +55,9 @@ function setTheme(mode) {
   }
 
   // Change Gisus theme
-  var iframe = document.querySelector('.giscus-frame');
-  if (iframe) {
-    var url = new URL(iframe.src);
-    url.searchParams.set('theme', mode);
-    iframe.src = url.toString();
+  var comments = document.querySelector('#comments');
+  if (comments) {
+    comments.setAttribute("theme", mode);
   }
 
   updateThemeIcons(mode);

--- a/static/js/toggle-theme.js
+++ b/static/js/toggle-theme.js
@@ -54,6 +54,14 @@ function setTheme(mode) {
     document.body.classList.add("light");
   }
 
+  // Change Gisus theme
+  var iframe = document.querySelector('.giscus-frame');
+  if (iframe) {
+    var url = new URL(iframe.src);
+    url.searchParams.set('theme', mode);
+    iframe.src = url.toString();
+  }
+
   updateThemeIcons(mode);
 }
 

--- a/templates/_giscus_script.html
+++ b/templates/_giscus_script.html
@@ -2,7 +2,7 @@
   src="https://giscus.app/client.js"
   data-repo="{{ config.extra.giscus_repo }}"
   data-repo-id="{{ config.extra.giscus_repo_id }}"
-  data-category="General"
+  data-category="{{ config.extra.giscus_data_category | default(value="General") }}"
   data-category-id="{{ config.extra.giscus_data_category_id }}"
   data-mapping="pathname"
   data-strict="0"

--- a/templates/_giscus_script.html
+++ b/templates/_giscus_script.html
@@ -1,17 +1,15 @@
-<script
-  src="https://giscus.app/client.js"
-  data-repo="{{ config.extra.giscus_repo }}"
-  data-repo-id="{{ config.extra.giscus_repo_id }}"
-  data-category="{{ config.extra.giscus_data_category | default(value="General") }}"
-  data-category-id="{{ config.extra.giscus_data_category_id }}"
-  data-mapping="pathname"
-  data-strict="0"
-  data-reactions-enabled="1"
-  data-emit-metadata="0"
-  data-input-position="bottom"
-  data-theme="preferred_color_scheme"
-  data-lang="en"
-  data-loading="lazy"
-  crossorigin="anonymous"
-  async
-></script>
+<script type="module" src="https://esm.sh/giscus"></script>
+<giscus-widget
+  id="comments"
+  repo="{{ config.extra.giscus_repo }}"
+  repoid="{{ config.extra.giscus_repo_id }}"
+  category="{{ config.extra.giscus_data_category | default(value="General") }}"
+  categoryid="{{ config.extra.giscus_data_category_id }}"
+  mapping="pathname"
+  reactionsenabled="1"
+  emitmetadata="0"
+  inputposition="bottom"
+  theme="preferred_color_scheme"
+  lang="en"
+  loading="lazy"
+></giscus-widget>

--- a/templates/partials/fonts.html
+++ b/templates/partials/fonts.html
@@ -1,5 +1,5 @@
 {% set cdn     = config.extra.font_cdn     | default(value="googlefont") %}
-{% if cdn == "zeoseven" %}
+{% if cdn == "zeoseven" or cdn == "googlefont" %}
   {% set weights = config.extra.font_weights | default(value=[400, 700]) %}
 {% else %}
   {% set weights = config.extra.font_weights | default(value=["main"]) %}

--- a/templates/partials/fonts.html
+++ b/templates/partials/fonts.html
@@ -21,7 +21,7 @@
 {% elif cdn == "zeoseven" %}
 
   <!-- ZeoSeven -->
-  {% set font_url = "https://fontsapi.zeoseven.com/{{ config.extra.font_id }}/main/result.css" %}
+  {% set font_url = "https://fontsapi.zeoseven.com/" ~ config.extra.font_id ~ "/main/result.css" %}
   <link rel="preload" as="style" crossorigin
       href="{{ font_url }}"
       onload="this.rel='stylesheet'"

--- a/templates/partials/fonts.html
+++ b/templates/partials/fonts.html
@@ -1,9 +1,19 @@
 {% set cdn     = config.extra.font_cdn     | default(value="googlefont") %}
-{% set weights = config.extra.font_weights | default(value=[400, 700]) %}
+{% if cdn == "zeoseven" %}
+  {% set weights = config.extra.font_weights | default(value=[400, 700]) %}
+{% else %}
+  {% set weights = config.extra.font_weights | default(value=["main"]) %}
+{% endif %}
 {% set name    = config.extra.font_name    | default(value="JetBrains Mono") %}
 {% set display = config.extra.font_display | default(value="swap") %}
 
-{% if cdn == "fontsource" %}
+{% if cdn == "custom" %}
+
+  {% for url in config.extra.font_css_urls %}
+    <link href="{{ url }}" rel="stylesheet">
+  {% endfor %}
+
+{% elif cdn == "fontsource" %}
 
   <!-- FontSource.org -->
   <style>
@@ -21,14 +31,16 @@
 {% elif cdn == "zeoseven" %}
 
   <!-- ZeoSeven -->
-  {% set font_url = "https://fontsapi.zeoseven.com/" ~ config.extra.font_id ~ "/main/result.css" %}
-  <link rel="preload" as="style" crossorigin
-      href="{{ font_url }}"
-      onload="this.rel='stylesheet'"
-      onerror="this.href='{{ font_url }}'" />
-  <noscript>
-      <link rel="stylesheet" href="{{ font_url }}" />
-  </noscript>
+  {% for weight in weights %}
+    {% set font_url = "https://fontsapi.zeoseven.com/" ~ config.extra.font_id ~ "/" ~ weight ~"/result.css" %}
+    <link rel="preload" as="style" crossorigin
+        href="{{ font_url }}"
+        onload="this.rel='stylesheet'"
+        onerror="this.href='{{ font_url }}'" />
+    <noscript>
+        <link rel="stylesheet" href="{{ font_url }}" />
+    </noscript>
+  {% endfor %}
 
 {% else %}
 

--- a/templates/partials/fonts.html
+++ b/templates/partials/fonts.html
@@ -1,4 +1,52 @@
-<!-- Google Fonts -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+{% set cdn     = config.extra.font_cdn     | default(value="googlefont") %}
+{% set weights = config.extra.font_weights | default(value=[400, 700]) %}
+{% set name    = config.extra.font_name    | default(value="JetBrains Mono") %}
+{% set display = config.extra.font_display | default(value="swap") %}
+
+{% if cdn == "fontsource" %}
+
+  <!-- FontSource.org -->
+  <style>
+  {% for weight in weights %}
+  @font-face {
+    font-family: {{ name }};
+    font-style: normal;
+    font-display: {{ display }};
+    font-weight: {{ weight }};
+    src: url(https://cdn.jsdelivr.net/fontsource/fonts/{{ name | slugify }}@latest/latin-{{ weight }}-normal.woff2) format('woff2');
+  }
+  {% endfor %}
+  </style>
+
+{% elif cdn == "zeoseven" %}
+
+  <!-- ZeoSeven -->
+  {% set font_url = "https://fontsapi.zeoseven.com/{{ config.extra.font_id }}/main/result.css" %}
+  <link rel="preload" as="style" crossorigin
+      href="{{ font_url }}"
+      onload="this.rel='stylesheet'"
+      onerror="this.href='{{ font_url }}'" />
+  <noscript>
+      <link rel="stylesheet" href="{{ font_url }}" />
+  </noscript>
+
+{% else %}
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  {% for weight in weights %}
+  <link href="https://fonts.googleapis.com/css2?family={{ name | replace(from=" ", to="+")}}:wght@{{ weight }}&display={{ display }}" rel="stylesheet">
+  {% endfor %}
+
+{% endif %}
+
+<!-- Forcing Font -->
+<style>
+body {
+  font-family:
+    "{{ name }}", Menlo, Monaco, Lucida Console, Liberation Mono,
+    DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New,
+    monospace, serif !important;
+}
+</style>


### PR DESCRIPTION
Thank you for creating this fancy theme! I'm using it for my new blog and want to contribute some important features.

## Custom font

I want to use [Maple Mono](https://github.com/subframe7536/maple-font) for chinses characters. But it is not on google font. So I added some optional configs for adjustable font cdn.

```toml
[extra]
font_cdn = "googlefont"
font_name = "JetBrians Mono"

# Or https://fontsource.org/
font_cdn = "fontsource"
font_name = "Maple Mono"

# Or https://fonts.zeoseven.com/
font_cdn = "zeoseven"
font_name = "Maple Mono NF CN"
font_id = 442
```

`font_weights` and `font_display` are all adjustable.

## Giscus sync theme

```js
var iframe = document.querySelector('.giscus-frame');
if (iframe) {
  var url = new URL(iframe.src);
  url.searchParams.set('theme', mode);
  iframe.src = url.toString();
}
```

## `giscus_data_category`

I want to use `Comments` instead of `General`. `giscus_data_category` is added as optional config for it.