### PR TITLE
fix(giscus): properly apply theme on initial post load for Giscus

### DIFF
--- a/static/js/toggle-theme.js
+++ b/static/js/toggle-theme.js
@@ -54,12 +54,27 @@ function setTheme(mode) {
     document.body.classList.add("light");
   }
 
-  // Change Gisus theme
+  // Change Giscus theme
   var iframe = document.querySelector(".giscus-frame");
   if (iframe) {
     var url = new URL(iframe.src);
     url.searchParams.set("theme", mode);
     iframe.src = url.toString();
+  } else {
+    // If iframe doesn't exist yet, set it via message when it loads
+    window.addEventListener("message", function setInitialGiscusTheme(event) {
+      if (event.origin !== "https://giscus.app") return;
+      if (event.data.giscus) {
+        iframe = document.querySelector(".giscus-frame");
+        if (iframe) {
+          iframe.contentWindow.postMessage(
+            { giscus: { setConfig: { theme: mode } } },
+            "https://giscus.app",
+          );
+          window.removeEventListener("message", setInitialGiscusTheme);
+        }
+      }
+    });
   }
 
   updateThemeIcons(mode);

--- a/templates/_giscus_script.html
+++ b/templates/_giscus_script.html
@@ -9,7 +9,15 @@
   data-reactions-enabled="1"
   data-emit-metadata="0"
   data-input-position="bottom"
+
+  {% if config.extra.theme == "light" %}
+  data-theme="light"
+  {% elif config.extra.theme == "dark" %}
+  data-theme="dark"
+  {% else %}
   data-theme="preferred_color_scheme"
+  {% endif %}
+
   data-lang="en"
   data-loading="lazy"
   crossorigin="anonymous"


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

- use `postMessage` handshake with Giscus iframe to properly set the theme when the element loads

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #35 
