### PR TITLE
Prefer page.description over summary in post macro

### DIFF
--- a/templates/macros/post_macros.html
+++ b/templates/macros/post_macros.html
@@ -23,9 +23,13 @@
             </h2>
             <data class="muted">{{ self::meta(page=page) }}</data>
         </header>
-        {% if page.summary %}
-            <section itemprop="summary">
-                {{ page.summary | safe }}
+        {% if page.description or page.summary %}
+        <section itemprop="summary">
+	            {% if page.description %}
+                    {{ page.description | safe }}
+	            {% else %}
+	            {{ page.summary | safe }}
+	            {% endif %}
                 <nav class="readmore"><a itemprop="url" href="{{ page.permalink | safe }}">Read More&nbsp;&raquo;</a></nav>
             </section>
         {% endif %}


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

When rendering article listings on the main page, the template currently relies on `page.summary`, which is derived from the content appearing before the `<!-- more -->` marker.  However, authors may explicitly define a description in the page front matter to control how an article is summarized.

This change updates the post macro to prefer `page.description` when it is provided, and fall back to the automatically generated `page.summary` otherwise.  This allows authors to explicitly control summary text without changing existing behavior for posts that do not define a description.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
Given the following:

```
+++
title = "Suffering = Pain * Resistance (and the Role of Self-Compassion)"
description = "A personal reflection on how resistance amplifies pain, and how acceptance and self-compassion can meaningfully reduce suffering."
date = 2026-01-05T18:02:29+03:00
publishDate = 2026-01-05T18:02:29+03:00
draft = false

[taxonomies]
tags = ["life", "philosophy", "mental-health"]
categories = ["Life"]

[extra]
toc = true
+++

**TL;DR:** *Pain is unavoidable. Resistance multiplies it. Acceptance and Self-compassion reduces the damage.*

<!-- more -->
```

Before:

<img width="1237" height="320" alt="image" src="https://github.com/user-attachments/assets/72bc235a-edc9-4f97-a05d-20d24e849636" />

After:

<img width="1297" height="336" alt="image" src="https://github.com/user-attachments/assets/9566204d-c602-4792-9bed-6c8c9af89b37" />

